### PR TITLE
Jan 2023 update

### DIFF
--- a/components/Charts/Choropleth/Section.tsx
+++ b/components/Charts/Choropleth/Section.tsx
@@ -51,7 +51,7 @@ const ChoroplethSection = () => {
         <div className="section-title-layout">
           <h3 className="section-title">{t("choropleth_title")}</h3>
           <DateSignature
-            date="2020-11-1"
+            date="2020/11/1"
             option={{ year: "numeric", month: undefined, day: undefined }}
           />
         </div>

--- a/components/Charts/Choropleth/Section.tsx
+++ b/components/Charts/Choropleth/Section.tsx
@@ -51,7 +51,7 @@ const ChoroplethSection = () => {
         <div className="section-title-layout">
           <h3 className="section-title">{t("choropleth_title")}</h3>
           <DateSignature
-            date="2020"
+            date="2020-11-1"
             option={{ year: "numeric", month: undefined, day: undefined }}
           />
         </div>

--- a/components/DateSignature/index.tsx
+++ b/components/DateSignature/index.tsx
@@ -7,7 +7,7 @@ interface DateSignatureProps {
 }
 
 const DateSignature: FunctionComponent<DateSignatureProps> = ({
-  date = "2022-11-1",
+  date = "2022/11/1",
   option = {
     year: "numeric",
     month: "long",

--- a/pages/[state]/[area].tsx
+++ b/pages/[state]/[area].tsx
@@ -177,7 +177,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
   });
 
   //   return { paths: [...en, ...ms, ...zh, ...ta], fallback: false };
-  return { paths: [], fallback: false };
+  return { paths: [], fallback: "blocking" };
 };
 
 interface IParams extends ParsedUrlQuery {

--- a/pages/[state]/[area].tsx
+++ b/pages/[state]/[area].tsx
@@ -176,7 +176,8 @@ export const getStaticPaths: GetStaticPaths = async () => {
     });
   });
 
-  return { paths: [...en, ...ms, ...zh, ...ta], fallback: false };
+  //   return { paths: [...en, ...ms, ...zh, ...ta], fallback: false };
+  return { paths: [], fallback: false };
 };
 
 interface IParams extends ParsedUrlQuery {

--- a/pages/[state]/index.tsx
+++ b/pages/[state]/index.tsx
@@ -166,8 +166,8 @@ export const getStaticPaths: GetStaticPaths = async () => {
     ta.push({ params: { state: formattedState }, locale: "zh-CN" });
   });
 
-  //   return { paths: [...en, ...ms, ...zh, ...ta], fallback: false };
-  return { paths: [], fallback: false };
+  // return { paths: [...en, ...ms, ...zh, ...ta], fallback: false };
+  return { paths: [], fallback: "blocking" };
 };
 
 interface IParams extends ParsedUrlQuery {

--- a/pages/[state]/index.tsx
+++ b/pages/[state]/index.tsx
@@ -166,7 +166,8 @@ export const getStaticPaths: GetStaticPaths = async () => {
     ta.push({ params: { state: formattedState }, locale: "zh-CN" });
   });
 
-  return { paths: [...en, ...ms, ...zh, ...ta], fallback: false };
+  //   return { paths: [...en, ...ms, ...zh, ...ta], fallback: false };
+  return { paths: [], fallback: false };
 };
 
 interface IParams extends ParsedUrlQuery {


### PR DESCRIPTION
- fix: apple's js unable to parse `YYYY-MM-DD` format. Replaced with `YYYY/MM/DD`
- feat: runtime ISR build for the `/state` & `/state/area`